### PR TITLE
Bugfix/missing-resources

### DIFF
--- a/include/api.js
+++ b/include/api.js
@@ -878,21 +878,12 @@ hapi.ajax = function(p) {
       };
     }
 
-    var test = {
-      'highcharts': [
-        '6.0.0',
-        '6.0.1',
-        '6.0.2',
-        '6.0.3'
-      ]
-    };
-
     function load(data) {
       vselector.style.display = '';
       body.innerHTML = '';
-      Object.keys(test).forEach(function (group) {
+      Object.keys(data).forEach(function (group) {
         var groupIns = addGroup(group);
-        test[group].forEach(function (version) {
+        data[group].forEach(function (version) {
           groupIns.addChild(version);
         });
       });
@@ -902,7 +893,7 @@ hapi.ajax = function(p) {
 
     hapi.ajax({
       url: hapi.versionLocation,
-      success: load,
+      success: load
     });
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ const mkdir = require('mkdirp');
 const marked = require('marked'); // markdown parser
 const async = require('async');
 const fs = require('fs');
+const join = require('path').join;
 
 var products = {};
 
@@ -272,6 +273,58 @@ function mergeNode(achildren, bchildren, fullExclude) {
     }
   });
 }
+
+/**
+ * Promisify functions which has the error-first callback style.
+ * In NodeJS v8 this polyfill can be replaced with util.promisify.
+ *
+ * @param {Function} fn The original function.
+ * @returns {Function} Returns a promisified function.
+ */
+const promisify = (fn) => {
+    return function () {
+        const ctx = this;
+        const args = Array.from(arguments);
+        return new Promise((resolve, reject) => {
+            args.push((err, data) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(data);
+                }
+            });
+            fn.apply(ctx, args);
+        });
+    };
+};
+
+const lstat = promisify(fs.lstat);
+const readdir = promisify(fs.readdir);
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
+
+const copyFile = (from, to) => {
+    return readFile(from)
+        .then((data) => writeFile(to, data));
+};
+
+const copyDir = (from, to) => {
+    return readdir(from)
+        .then((files) => {
+            const promises = files.map((filename) => {
+                const pathFrom = join(from, filename);
+                const pathTo = join(to, filename);
+                return lstat(pathFrom)
+                    .then((stats) => (
+                        stats.isDirectory() ?
+                        mkdirPromise(pathTo).then(() => copyDir(pathFrom, pathTo)) :
+                        copyFile(pathFrom, pathTo)
+                    ));
+            });
+
+            return Promise.all(promises);
+        });
+};
 
 module.exports = function (input, outputPath, currentOnly, fn) {
     var versionFuns = [],
@@ -720,16 +773,7 @@ module.exports = function (input, outputPath, currentOnly, fn) {
 
     function copyIncludes(outPath) {
         var incPath = __dirname + '/../include/';
-
-        fs.readdir(incPath, function (err, files) {
-            if (err) return false;
-
-            files.forEach(function (f) {
-                if (f[0] !== '.') { // Ignore .DS_Store etc.
-                    fs.writeFileSync(outPath + f, fs.readFileSync(incPath + f));
-                }
-            });
-        });
+        return copyDir(incPath, outPath);
     }
 
     /**
@@ -912,13 +956,7 @@ module.exports = function (input, outputPath, currentOnly, fn) {
      * @param path Path to the directory.
      * @return Returns a Promise which resolves when the directory is created.
      */
-    mkdirPromise = (path) => {
-        return new Promise((resolve) => {
-            mkdir(path, () => {
-                resolve();
-            });
-        });
-    };
+    mkdirPromise = promisify(mkdir);
 
     // Output each product in a separate folder,
     // with the sub-folder being version numbers
@@ -1046,9 +1084,8 @@ module.exports = function (input, outputPath, currentOnly, fn) {
                                 productToc,
                                 constr
                             );
-
-                            copyIncludes(op);
-                        });
+                        })
+                        .then(() => copyIncludes(op));
                     });
                 });
                 return Promise.all(promisesVersions)


### PR DESCRIPTION
# Description
The function copyIncludes was unable to copy files in subdirectories, e.g. fonts, resulting in missing resources in the generated api.
Added function `copyDir` which recursively copies all files in a folder.

Also removed a test object which was left in api.js.